### PR TITLE
Add faiss as a dependency

### DIFF
--- a/packages/blockingpy-core/pyproject.toml
+++ b/packages/blockingpy-core/pyproject.toml
@@ -44,6 +44,7 @@ pandas = ">=2.2.0,<3.0.0"
 model2vec = "^0.4.1"
 igraph = "^0.11.9"
 mlpack = ">=4.4.0, <5.0.0"
+faiss-cpu = "^1.12.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### Issue
https://github.com/ncn-foreigners/BlockingPy/issues/9

### Testing
```bash
((.venv) ) ➜  BlockingPy git:(main) ✗ pytest
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/akritaagarwal/Personal/BlockingPy
configfile: pyproject.toml
plugins: anyio-4.10.0
collected 199 items                                                                                                                                                                                                                                 

tests/test_annoy_blocker.py .........X.unloaded
.unloaded
....x.                                                                                                                                                                                                [  9%]
tests/test_blocking.py ....................................                                                                                                                                                                                   [ 27%]
tests/test_blocking_result.py ..                                                                                                                                                                                                              [ 28%]
tests/test_controls.py .....                                                                                                                                                                                                                  [ 30%]
tests/test_datasets.py ..                                                                                                                                                                                                                     [ 31%]
tests/test_faiss_blocker.py .........................                                                                                                                                                                                         [ 44%]
tests/test_gpu_faiss.py ssssssssssssssssssssss                                                                                                                                                                                                [ 55%]
tests/test_hnsw_blocker.py ......................                                                                                                                                                                                             [ 66%]
tests/test_mlpack_blocker.py ..................                                                                                                                                                                                               [ 75%]
tests/test_nnd_blocker.py .....................                                                                                                                                                                                               [ 85%]
tests/test_text_transform.py ......                                                                                                                                                                                                           [ 88%]
tests/test_voyager_blocker.py ......................                                                                                                                                                                                          [100%]

========================================================================================= 175 passed, 22 skipped, 1 xfailed, 1 xpassed in 67.48s (0:01:07) ==========================================================================================
((.venv) ) ➜  BlockingPy git:(main) ✗ 
```